### PR TITLE
fix(settings): restore enum-driven App Icon list after bad merge

### DIFF
--- a/apps/mobile_app/lib/features/settings/presentation/settings_bottom_sheet.dart
+++ b/apps/mobile_app/lib/features/settings/presentation/settings_bottom_sheet.dart
@@ -288,27 +288,6 @@ class _AppIconView extends ConsumerWidget {
               onTap: () => setStyle(style),
               imageSize: imageSize,
             ),
-          PreviewOptionTile(
-            title: 'Classic',
-            imageAsset: 'assets/icons/companion.svg',
-            selected: s.appIconStyle == AppIconStyle.classic,
-            onTap: () => setStyle(AppIconStyle.classic),
-            imageSize: imageSize,
-          ),
-          PreviewOptionTile(
-            title: 'Outline',
-            imageAsset: 'assets/icons/companion.svg',
-            selected: s.appIconStyle == AppIconStyle.outline,
-            onTap: () => setStyle(AppIconStyle.outline),
-            imageSize: imageSize,
-          ),
-          PreviewOptionTile(
-            title: 'Gradient',
-            imageAsset: 'assets/icons/companion.svg',
-            selected: s.appIconStyle == AppIconStyle.gradient,
-            onTap: () => setStyle(AppIconStyle.gradient),
-            imageSize: imageSize,
-          ),
         ],
       ),
     );


### PR DESCRIPTION
## Summary
Restore the **enum-driven** App Icon list in Settings. A previous merge brought back three hardcoded `PreviewOptionTile` entries and removed the loop over `AppIconStyle.values`.

## What changed
- Replace hardcoded tiles with:
  ```dart
  for (final style in AppIconStyle.values)
    PreviewOptionTile(...);
