### PR TITLE
feat(settings): hide App Icon option on Web builds

### DIFF
--- a/apps/mobile_app/lib/features/settings/presentation/settings_bottom_sheet.dart
+++ b/apps/mobile_app/lib/features/settings/presentation/settings_bottom_sheet.dart
@@ -1,4 +1,5 @@
-import 'package:flutter/foundation.dart' show TargetPlatform, defaultTargetPlatform, kIsWeb;
+import 'package:flutter/foundation.dart'
+    show TargetPlatform, defaultTargetPlatform, kIsWeb;
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:mobile_app/features/settings/domain/app_settings.dart';
@@ -32,9 +33,9 @@ class _SettingsHomeView extends ConsumerWidget {
   const _SettingsHomeView();
 
   bool get _showAppIconOption =>
-  !kIsWeb &&
-  (defaultTargetPlatform == TargetPlatform.iOS ||
-   defaultTargetPlatform == TargetPlatform.android);
+      !kIsWeb &&
+      (defaultTargetPlatform == TargetPlatform.iOS ||
+          defaultTargetPlatform == TargetPlatform.android);
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {

--- a/apps/mobile_app/lib/features/settings/presentation/settings_bottom_sheet.dart
+++ b/apps/mobile_app/lib/features/settings/presentation/settings_bottom_sheet.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart' show TargetPlatform, defaultTargetPlatform, kIsWeb;
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:mobile_app/features/settings/domain/app_settings.dart';
@@ -29,6 +30,11 @@ class SettingsBottomSheet extends StatelessWidget {
 
 class _SettingsHomeView extends ConsumerWidget {
   const _SettingsHomeView();
+
+  bool get _showAppIconOption =>
+  !kIsWeb &&
+  (defaultTargetPlatform == TargetPlatform.iOS ||
+   defaultTargetPlatform == TargetPlatform.android);
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -74,13 +80,15 @@ class _SettingsHomeView extends ConsumerWidget {
                           .read(settingsViewModelProvider.notifier)
                           .setSound(enabled: v),
                     ),
-                    const Divider(height: 1),
-                    ListTile(
-                      title: const Text('App icon'),
-                      subtitle: Text(_appIconLabel(s.appIconStyle)),
-                      trailing: const Icon(Icons.chevron_right),
-                      onTap: () => _push(context, const _AppIconView()),
-                    ),
+                    if (_showAppIconOption) ...[
+                      const Divider(height: 1),
+                      ListTile(
+                        title: const Text('App icon'),
+                        subtitle: Text(_appIconLabel(s.appIconStyle)),
+                        trailing: const Icon(Icons.chevron_right),
+                        onTap: () => _push(context, const _AppIconView()),
+                      ),
+                    ],
                     const Divider(height: 1),
                     ListTile(
                       title: const Text('Set goal'),
@@ -260,8 +268,35 @@ class _AppIconView extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final s = ref.watch(settingsViewModelProvider).value ?? const AppSettings();
+    if (kIsWeb) {
+      return _SheetScaffold(
+        title: 'App icon',
+        body: Padding(
+          padding: const EdgeInsets.fromLTRB(16, 12, 16, 24),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                'Not available on Web',
+                style: Theme.of(context).textTheme.titleMedium,
+              ),
+              const SizedBox(height: 8),
+              Text(
+                'Changing the app icon is supported only on installed apps (iOS/Android/desktop).',
+                style: Theme.of(context).textTheme.bodyMedium,
+              ),
+              const SizedBox(height: 12),
+              FilledButton(
+                onPressed: () => Navigator.of(context).maybePop(),
+                child: const Text('Close'),
+              ),
+            ],
+          ),
+        ),
+      );
+    }
 
+    final s = ref.watch(settingsViewModelProvider).value ?? const AppSettings();
     final w = MediaQuery.of(context).size.width;
     final imageSize = (w * 0.28).clamp(92.0, 140.0);
 
@@ -279,7 +314,6 @@ class _AppIconView extends ConsumerWidget {
             style: Theme.of(context).textTheme.titleMedium,
           ),
           const SizedBox(height: 12),
-
           for (final style in AppIconStyle.values)
             PreviewOptionTile(
               title: style.label,


### PR DESCRIPTION
## Description
This PR hides the **App Icon** settings option when running on **Web builds**.  
Changing the app icon is only supported on installed apps (iOS, Android, Desktop).  

### Key changes
- Wrapped `App icon` ListTile in `_SettingsHomeView` with a `!kIsWeb` check.  
- Added a safe **stub view** in `_AppIconView` for Web users, displaying a friendly message.  
- iOS / Android / Desktop remain unaffected.

### How to test
1. Run the app on **Web**:
   - Open Settings → App settings.  
   - The **App icon** option should be hidden.  
   - If you try to navigate directly to the App Icon screen, you’ll see a stub screen.  
2. Run the app on **Android / iOS / Desktop**:
   - The App icon option remains available and works as before.

### Screenshots
| Platform                | Behavior                               | Screenshot |
|--------------------------|----------------------------------------|------------|
| **Web**                  | Stub screen shown, option hidden       | <img width="280" alt="web-stub" src="https://github.com/user-attachments/assets/7ccd2ca1-2ee4-4a83-8532-5baa2ea9284b" /> |
| **Android/iOS/Desktop**  | Option visible, works as expected      | <img width="280" alt="android-icon" src="https://github.com/user-attachments/assets/7b66db30-c592-4719-ad65-bee0d3a0e882" /> |
