### PR TITLE
chore(repo): enforce LF line endings across project

### DIFF
--- a/apps/mobile_app/.gitattributes
+++ b/apps/mobile_app/.gitattributes
@@ -1,7 +1,5 @@
-* text=auto
+* text=auto eol=lf
 
-linux/** text eol=lf
-web/**   text eol=lf
 *.sh     text eol=lf
 *.yaml   text eol=lf
 *.yml    text eol=lf


### PR DESCRIPTION
### Summary
This PR introduces a `.gitattributes` configuration to enforce **LF** line endings across the project.  
This helps maintain consistency between different environments (Windows, Linux, macOS) and prevents unnecessary diffs caused by CRLF vs LF conversions.

## Changes
- Added `.gitattributes` file with global LF enforcement
- Explicit LF rules for scripts and config files (`.sh`, `.yaml`, `.yml`, `.cmake`)

## How to test
1. Pull the branch and run:
   ```bash
   git add --renormalize .
   git status
