### PR TITLE
feat(profile): add generated avatar support

### DIFF
--- a/apps/mobile_app/lib/features/profile/data/profile_repository.dart
+++ b/apps/mobile_app/lib/features/profile/data/profile_repository.dart
@@ -7,12 +7,7 @@ abstract class ProfileRepository {
 }
 
 class MockProfileRepository implements ProfileRepository {
-  Profile _p = const Profile(
-    id: 'u_1',
-    displayName: 'Guest',
-    avatarUrl:
-        'https://lh3.googleusercontent.com/aida-public/AB6AXuDyuskrtSKMolDvy2LlGZGaWWBQfJibOP9eKgDZBWS2_49JkvD3PEEYjFyCIYugd7O9zxVuP2ExLn-ghO-Al6urv-0Ijvcb5A-_QUuFVnE2s6vPyZeGTv8v86K2SMspWYcZYBRNEfCEP6BL7yv05FVZx6Wdf13U1HZbGpCob-QxEUABAXxyAP9sDTIWLKQOSfrqTtF4N_vDBLSpBWvZa9vOC3W5DSlVECa6CAYY2pAHx35EPneq_cTb_a-63te8CT9KfBDSTmgIr68',
-  );
+  Profile _p = const Profile(id: 'u_1', displayName: 'Guest', avatarUrl: '');
 
   @override
   Future<Profile> load() async {

--- a/apps/mobile_app/lib/features/profile/presentation/pages/profile_page.dart
+++ b/apps/mobile_app/lib/features/profile/presentation/pages/profile_page.dart
@@ -89,10 +89,15 @@ class _ProfileHeader extends ConsumerWidget {
     final avatarUrl = profile?.avatarUrl;
     final bioText = (bio?.isEmpty ?? true) ? 'Add a bio' : bio!;
 
+    final seed = (profile?.displayName.trim().isNotEmpty ?? false)
+        ? profile!.displayName.trim()
+        : (profile?.id ?? 'guest');
+
     return Column(
       children: [
         AvatarBlock(
           imageUrl: avatarUrl,
+          seed: seed,
           onEditAvatar: () {
             // TODO(killursxlf): picker + upload to Supabase Storage
           },

--- a/apps/mobile_app/lib/features/profile/presentation/widgets/avatar_block.dart
+++ b/apps/mobile_app/lib/features/profile/presentation/widgets/avatar_block.dart
@@ -1,45 +1,56 @@
 import 'package:flutter/material.dart';
+import 'package:mobile_app/shared/avatar/generated_avatar.dart';
 
 class AvatarBlock extends StatelessWidget {
-  const AvatarBlock({required this.onEditAvatar, super.key, this.imageUrl});
+  const AvatarBlock({
+    required this.onEditAvatar,
+    required this.seed,
+    super.key,
+    this.imageUrl,
+    this.radius = 64,
+    this.showBorder = false,
+  });
 
   final String? imageUrl;
-  final VoidCallback onEditAvatar;
 
-  bool _isValidUrl(String? s) {
-    final u = Uri.tryParse(s ?? '');
-    return u != null && (u.isScheme('http') || u.isScheme('https'));
-  }
+  final String seed;
+
+  final double radius;
+
+  final bool showBorder;
+
+  final VoidCallback onEditAvatar;
 
   @override
   Widget build(BuildContext context) {
-    final ok = _isValidUrl(imageUrl);
+    final size = radius * 2;
+    final scheme = Theme.of(context).colorScheme;
 
     return Center(
       child: Stack(
         clipBehavior: Clip.none,
         children: [
-          CircleAvatar(
-            radius: 64,
-            backgroundColor: Theme.of(
-              context,
-            ).colorScheme.surfaceContainerHighest,
-            backgroundImage: ok ? NetworkImage(imageUrl!) : null,
-            child: ok
-                ? null
-                : Icon(
-                    Icons.person,
-                    size: 48,
-                    color: Theme.of(context).colorScheme.onSurfaceVariant,
-                  ),
+          DecoratedBox(
+            decoration: BoxDecoration(
+              shape: BoxShape.circle,
+              border: showBorder
+                  ? Border.all(color: scheme.outlineVariant)
+                  : null,
+            ),
+            child: GeneratedAvatar(size: size, seed: seed, url: imageUrl),
           ),
+
           Positioned(
             bottom: 0,
             right: 0,
             child: IconButton.filled(
               onPressed: onEditAvatar,
               icon: const Icon(Icons.edit, size: 18),
-              style: IconButton.styleFrom(shape: const CircleBorder()),
+              style: IconButton.styleFrom(
+                shape: const CircleBorder(),
+                padding: const EdgeInsets.all(10),
+              ),
+              tooltip: 'Edit avatar',
             ),
           ),
         ],

--- a/apps/mobile_app/lib/shared/avatar/generated_avatar.dart
+++ b/apps/mobile_app/lib/shared/avatar/generated_avatar.dart
@@ -1,0 +1,166 @@
+import 'package:flutter/material.dart';
+
+class GeneratedAvatar extends StatelessWidget {
+  const GeneratedAvatar({
+    required this.size,
+    required this.seed,
+    super.key,
+    this.url,
+    this.shape = BoxShape.circle,
+    this.border,
+  });
+
+  final double size;
+  final String seed;
+  final String? url;
+  final BoxShape shape;
+  final BoxBorder? border;
+
+  @override
+  Widget build(BuildContext context) {
+    final decoration = BoxDecoration(shape: shape, border: border);
+
+    if (url != null && url!.isNotEmpty) {
+      return Container(
+        width: size,
+        height: size,
+        decoration: decoration,
+        clipBehavior: Clip.antiAlias,
+        child: Image.network(
+          url!,
+          width: size,
+          height: size,
+          fit: BoxFit.cover,
+        ),
+      );
+    }
+
+    return Container(
+      width: size,
+      height: size,
+      decoration: decoration,
+      clipBehavior: Clip.antiAlias,
+      child: CustomPaint(
+        painter: _IdenticonPainter(seed: seed),
+        child: _InitialsFallback(seed: seed),
+      ),
+    );
+  }
+}
+
+class _SeedRng {
+  _SeedRng(String seed) : _state = seed.hashCode;
+  int _state;
+
+  int nextInt([int max = 1 << 31]) {
+    var x = _state;
+    x ^= x << 13;
+    x ^= x >> 17;
+    x ^= x << 5;
+    _state = x;
+    final res = x & 0x7fffffff;
+    return max <= 0 ? res : res % max;
+  }
+
+  double nextDouble() => nextInt() / 0x7fffffff;
+}
+
+class _IdenticonPainter extends CustomPainter {
+  _IdenticonPainter({required this.seed});
+
+  final String seed;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final rng = _SeedRng(seed);
+
+    final hue = rng.nextDouble() * 360.0;
+    final color = HSLColor.fromAHSL(1, hue, 0.55, 0.55).toColor();
+
+    final bg = HSLColor.fromAHSL(1, hue, 0.15, 0.92).toColor();
+    final paintBg = Paint()..color = bg;
+    final paintFg = Paint()..color = color;
+
+    final rrect = RRect.fromRectAndRadius(
+      Offset.zero & size,
+      const Radius.circular(999),
+    );
+    canvas.drawRRect(rrect, paintBg);
+
+    const n = 5;
+    final pad = size.width * 0.08;
+    final scale = (size.width - pad * 2) / n;
+    final origin = Offset(pad, pad);
+
+    final filled = List<List<bool>>.generate(
+      n,
+      (_) => List<bool>.filled(n, false),
+    );
+
+    for (var row = 0; row < n; row++) {
+      for (var col = 0; col < (n / 2).ceil(); col++) {
+        final isOn = rng.nextDouble() > 0.5;
+        filled[row][col] = isOn;
+        filled[row][n - 1 - col] = isOn;
+      }
+    }
+
+    var onCount = filled.fold<int>(
+      0,
+      (acc, r) => acc + r.where((e) => e).length,
+    );
+    for (; onCount < 3; onCount++) {
+      final rr = rng.nextInt(n);
+      final cc = rng.nextInt(n);
+      filled[rr][cc] = true;
+    }
+
+    for (var r = 0; r < n; r++) {
+      for (var c = 0; c < n; c++) {
+        if (!filled[r][c]) continue;
+        final rect = Rect.fromLTWH(
+          origin.dx + c * scale + scale * 0.12,
+          origin.dy + r * scale + scale * 0.12,
+          scale * 0.76,
+          scale * 0.76,
+        );
+        canvas.drawRRect(
+          RRect.fromRectAndRadius(rect, Radius.circular(scale * 0.18)),
+          paintFg,
+        );
+      }
+    }
+  }
+
+  @override
+  bool shouldRepaint(covariant _IdenticonPainter oldDelegate) =>
+      oldDelegate.seed != seed;
+}
+
+class _InitialsFallback extends StatelessWidget {
+  const _InitialsFallback({required this.seed});
+
+  final String seed;
+
+  @override
+  Widget build(BuildContext context) {
+    final parts = seed.trim().split(RegExp(r'\s+'));
+    final initials = parts.length == 1
+        ? parts.first.characters.take(2).toString().toUpperCase()
+        : ((parts[0].isNotEmpty ? parts[0][0] : '') +
+                  (parts.length > 1 && parts[1].isNotEmpty ? parts[1][0] : ''))
+              .toUpperCase();
+
+    return Center(
+      child: Text(
+        initials,
+        style: const TextStyle(
+          fontWeight: FontWeight.w700,
+          fontSize: 20,
+          letterSpacing: 1,
+          color: Colors.black54,
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## What was done
- Integrated `GeneratedAvatar` widget with identicon + initials fallback (`lib/shared/avatar/`)
- Updated `AvatarBlock` to accept `seed` + `imageUrl`
- Updated `ProfilePage` header to pass seed (`displayName` or `id`)
- Removed hardcoded default `avatarUrl` in `MockProfileRepository` (empty string triggers generated avatar)

