### PR TITLE
feat(catalog): introduce CoursePath component and integrate with TrackDetailPage

### DIFF
--- a/apps/mobile_app/lib/core/models/course_node.dart
+++ b/apps/mobile_app/lib/core/models/course_node.dart
@@ -1,0 +1,45 @@
+import 'package:flutter/foundation.dart';
+
+enum NodeType { lesson, practice, quiz, boss }
+
+enum NodeStatus { locked, available, done }
+
+@immutable
+class CourseNode {
+  const CourseNode({
+    required this.id,
+    required this.title,
+    required this.type,
+    this.status = NodeStatus.locked,
+    this.progress = 0,
+    this.prerequisites = const [],
+    this.order = 0,
+  });
+  final String id;
+  final String title;
+  final NodeType type;
+  final NodeStatus status;
+  final int progress;
+  final List<String> prerequisites;
+  final int order;
+
+  CourseNode copyWith({
+    String? id,
+    String? title,
+    NodeType? type,
+    NodeStatus? status,
+    int? progress,
+    List<String>? prerequisites,
+    int? order,
+  }) {
+    return CourseNode(
+      id: id ?? this.id,
+      title: title ?? this.title,
+      type: type ?? this.type,
+      status: status ?? this.status,
+      progress: progress ?? this.progress,
+      prerequisites: prerequisites ?? this.prerequisites,
+      order: order ?? this.order,
+    );
+  }
+}

--- a/apps/mobile_app/lib/features/catalog/presentation/viewmodels/course_path_provider.dart
+++ b/apps/mobile_app/lib/features/catalog/presentation/viewmodels/course_path_provider.dart
@@ -1,0 +1,65 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:mobile_app/core/models/course_node.dart';
+
+final coursePathProvider =
+    NotifierProvider<CoursePathController, List<CourseNode>>(
+      CoursePathController.new,
+    );
+
+class CoursePathController extends Notifier<List<CourseNode>> {
+  @override
+  List<CourseNode> build() {
+    return [
+      const CourseNode(
+        id: 'intro',
+        title: 'Intro',
+        type: NodeType.lesson,
+        status: NodeStatus.available,
+      ),
+      const CourseNode(
+        id: 'practice-1',
+        title: 'Practice 1',
+        type: NodeType.practice,
+        prerequisites: ['intro'],
+        order: 1,
+      ),
+      const CourseNode(
+        id: 'quiz-1',
+        title: 'Quiz 1',
+        type: NodeType.quiz,
+        prerequisites: ['practice-1'],
+        order: 2,
+      ),
+      const CourseNode(
+        id: 'practice-2',
+        title: 'Practice 2',
+        type: NodeType.practice,
+        prerequisites: ['quiz-1'],
+        order: 3,
+      ),
+    ];
+  }
+
+  void markDone(String id) {
+    final idx = state.indexWhere((n) => n.id == id);
+    if (idx == -1) return;
+
+    final updated = [...state];
+    updated[idx] = updated[idx].copyWith(
+      status: NodeStatus.done,
+      progress: 100,
+    );
+
+    for (var i = idx + 1; i < updated.length; i++) {
+      final node = updated[i];
+      final ok = node.prerequisites.every(
+        (p) => updated.any((n) => n.id == p && n.status == NodeStatus.done),
+      );
+      if (ok && node.status == NodeStatus.locked) {
+        updated[i] = node.copyWith(status: NodeStatus.available);
+        break;
+      }
+    }
+    state = updated;
+  }
+}

--- a/apps/mobile_app/lib/features/catalog/presentation/widgets/course_node_tile.dart
+++ b/apps/mobile_app/lib/features/catalog/presentation/widgets/course_node_tile.dart
@@ -1,0 +1,95 @@
+import 'package:flutter/material.dart';
+import 'package:mobile_app/core/models/course_node.dart';
+
+class CourseNodeTile extends StatelessWidget {
+  const CourseNodeTile({
+    required this.node,
+    required this.onTap,
+    super.key,
+    this.size = 84,
+  });
+
+  final CourseNode node;
+  final VoidCallback onTap;
+  final double size;
+
+  @override
+  Widget build(BuildContext context) {
+    final locked = node.status == NodeStatus.locked;
+
+    return Semantics(
+      button: true,
+      label: node.title,
+      child: GestureDetector(
+        onTap: locked ? null : onTap,
+        child: Opacity(
+          opacity: locked ? 0.55 : 1,
+          child: Container(
+            width: size,
+            height: size,
+            decoration: BoxDecoration(
+              color: Theme.of(context).colorScheme.surface,
+              borderRadius: BorderRadius.circular(18),
+              border: Border.all(
+                color: locked
+                    ? Theme.of(context).colorScheme.outlineVariant
+                    : Theme.of(
+                        context,
+                      ).colorScheme.primary.withValues(alpha: 0.65),
+                width: 2,
+              ),
+              boxShadow: [
+                BoxShadow(
+                  blurRadius: 12,
+                  offset: const Offset(0, 6),
+                  color: Colors.black.withValues(alpha: 0.25),
+                ),
+              ],
+            ),
+            alignment: Alignment.center,
+            child: _Inner(node: node),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _Inner extends StatelessWidget {
+  const _Inner({required this.node});
+  final CourseNode node;
+
+  @override
+  Widget build(BuildContext context) {
+    final icon = switch (node.type) {
+      NodeType.practice => Icons.bolt,
+      NodeType.quiz => Icons.help_outline,
+      NodeType.boss => Icons.star,
+      _ => Icons.play_arrow,
+    };
+
+    return Stack(
+      alignment: Alignment.center,
+      children: [
+        Icon(icon, size: 32),
+        if (node.status == NodeStatus.done)
+          const Positioned(
+            right: 6,
+            top: 6,
+            child: Icon(Icons.check, size: 18),
+          ),
+        if (node.status == NodeStatus.locked)
+          const Positioned(right: 6, top: 6, child: Icon(Icons.lock, size: 18)),
+        if (node.status == NodeStatus.available && node.progress > 0)
+          Positioned(
+            right: 6,
+            top: 6,
+            child: Text(
+              '${node.progress}%',
+              style: Theme.of(context).textTheme.labelSmall,
+            ),
+          ),
+      ],
+    );
+  }
+}

--- a/apps/mobile_app/lib/features/catalog/presentation/widgets/course_path.dart
+++ b/apps/mobile_app/lib/features/catalog/presentation/widgets/course_path.dart
@@ -1,0 +1,81 @@
+import 'package:flutter/material.dart';
+import 'package:mobile_app/core/models/course_node.dart';
+import 'package:mobile_app/features/catalog/presentation/widgets/course_node_tile.dart';
+import 'package:mobile_app/features/catalog/presentation/widgets/course_path_layout.dart';
+import 'package:mobile_app/features/catalog/presentation/widgets/course_path_painter.dart';
+
+class CoursePath extends StatelessWidget {
+  const CoursePath({
+    required this.nodes,
+    required this.onNodeTap,
+    super.key,
+    this.cols = 3,
+    this.itemSize = const Size(84, 84),
+    this.hGap = 48,
+    this.vGap = 64,
+  });
+
+  final List<CourseNode> nodes;
+  final void Function(CourseNode) onNodeTap;
+  final int cols;
+  final Size itemSize;
+  final double hGap;
+  final double vGap;
+
+  @override
+  Widget build(BuildContext context) {
+    final centers = SnakeLayout.place(
+      count: nodes.length,
+      cols: cols,
+      itemSize: itemSize,
+      hGap: hGap,
+      vGap: vGap,
+    );
+    final canvasSize = SnakeLayout.scrollSize(
+      count: nodes.length,
+      cols: cols,
+      itemSize: itemSize,
+      hGap: hGap,
+      vGap: vGap,
+    );
+
+    final theme = Theme.of(context);
+    final scheme = theme.colorScheme;
+    final connectorColor = theme.brightness == Brightness.dark
+        ? scheme.onSurfaceVariant
+        : scheme.outline;
+
+    return SingleChildScrollView(
+      padding: const EdgeInsets.symmetric(vertical: 24),
+      child: Center(
+        child: SizedBox(
+          width: canvasSize.width,
+          height: canvasSize.height,
+          child: Stack(
+            children: [
+              Positioned.fill(
+                child: CustomPaint(
+                  painter: CoursePathPainter(
+                    centers,
+                    color: connectorColor,
+                    strokeWidth: 6,
+                  ),
+                ),
+              ),
+              for (var i = 0; i < nodes.length; i++)
+                Positioned(
+                  left: centers[i].dx - itemSize.width / 2,
+                  top: centers[i].dy - itemSize.height / 2,
+                  child: CourseNodeTile(
+                    node: nodes[i],
+                    onTap: () => onNodeTap(nodes[i]),
+                    size: itemSize.width,
+                  ),
+                ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/apps/mobile_app/lib/features/catalog/presentation/widgets/course_path_layout.dart
+++ b/apps/mobile_app/lib/features/catalog/presentation/widgets/course_path_layout.dart
@@ -1,0 +1,35 @@
+import 'dart:ui';
+
+class SnakeLayout {
+  static List<Offset> place({
+    required int count,
+    required int cols,
+    required Size itemSize,
+    required double hGap,
+    required double vGap,
+  }) {
+    final points = <Offset>[];
+    for (var i = 0; i < count; i++) {
+      final row = i ~/ cols;
+      final col = i % cols;
+      final snakeCol = row.isEven ? col : (cols - 1 - col);
+      final x = snakeCol * (itemSize.width + hGap) + itemSize.width / 2;
+      final y = row * (itemSize.height + vGap) + itemSize.height / 2;
+      points.add(Offset(x, y));
+    }
+    return points;
+  }
+
+  static Size scrollSize({
+    required int count,
+    required int cols,
+    required Size itemSize,
+    required double hGap,
+    required double vGap,
+  }) {
+    final rows = (count / cols).ceil();
+    final width = cols * itemSize.width + (cols - 1) * hGap;
+    final height = rows * itemSize.height + (rows - 1) * vGap;
+    return Size(width, height);
+  }
+}

--- a/apps/mobile_app/lib/features/catalog/presentation/widgets/course_path_painter.dart
+++ b/apps/mobile_app/lib/features/catalog/presentation/widgets/course_path_painter.dart
@@ -1,0 +1,44 @@
+import 'package:flutter/material.dart';
+
+class CoursePathPainter extends CustomPainter {
+  CoursePathPainter(this.points, {required this.color, this.strokeWidth = 6});
+
+  final List<Offset> points;
+  final double strokeWidth;
+  final Color color;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final base = Paint()
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = strokeWidth + 2
+      ..color = color.withValues(alpha: 0.18)
+      ..strokeCap = StrokeCap.round;
+
+    final top = Paint()
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = strokeWidth
+      ..color = color.withValues(alpha: 0.75)
+      ..strokeCap = StrokeCap.round;
+
+    for (var i = 0; i < points.length - 1; i++) {
+      final a = points[i];
+      final b = points[i + 1];
+      final midX = (a.dx + b.dx) / 2;
+
+      final path = Path()
+        ..moveTo(a.dx, a.dy)
+        ..quadraticBezierTo(midX, a.dy, b.dx, b.dy);
+
+      canvas
+        ..drawPath(path, base)
+        ..drawPath(path, top);
+    }
+  }
+
+  @override
+  bool shouldRepaint(covariant CoursePathPainter old) =>
+      old.points != points ||
+      old.strokeWidth != strokeWidth ||
+      old.color != color;
+}


### PR DESCRIPTION
### Summary
- Added reusable CoursePath UI component with snake layout
- Integrated on TrackDetailPage (replaces static lesson list)
- Improved line contrast for light/dark themes

### Next steps
- Bind CoursePath to real progress repository
- Implement node detail pages (lesson, quiz, practice)
- Animate node unlock transitions
