### PR TITLE
feat(leaderboard): MVP — UI page + XP backend (views, triggers, RLS, migrations)

### DIFF
--- a/apps/mobile_app/lib/core/models/course_node.dart
+++ b/apps/mobile_app/lib/core/models/course_node.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/foundation.dart';
 
 enum NodeType { lesson, practice, quiz, boss }
+
 enum NodeStatus { locked, available, done }
 
 @immutable

--- a/apps/mobile_app/lib/core/models/lesson.dart
+++ b/apps/mobile_app/lib/core/models/lesson.dart
@@ -47,7 +47,6 @@ class LessonSlide {
   final int order;
 }
 
-
 typedef LessonKey = ({String courseId, String lessonId});
 
 extension LessonX on Lesson {

--- a/apps/mobile_app/lib/core/routing/app_router.dart
+++ b/apps/mobile_app/lib/core/routing/app_router.dart
@@ -118,8 +118,7 @@ final appRouterProvider = Provider<GoRouter>((ref) {
               GoRoute(
                 path: '/profile',
                 pageBuilder: (ctx, state) {
-                  final uid =
-                      Supabase.instance.client.auth.currentUser?.id;
+                  final uid = Supabase.instance.client.auth.currentUser?.id;
                   return NoTransitionPage(
                     child: KeyedSubtree(
                       key: ValueKey(uid),
@@ -160,8 +159,7 @@ final appRouterProvider = Provider<GoRouter>((ref) {
       final isRoot = loc == '/' || loc == SplashPage.routePath;
       final isAuthFlow = loc.startsWith('/auth/');
       final isWelcome =
-          loc == '/profile/welcome' ||
-          loc.startsWith('/profile/welcome');
+          loc == '/profile/welcome' || loc.startsWith('/profile/welcome');
       final isOnboarding = loc == OnboardingPage.routePath;
 
       if (!isAuthed) {
@@ -206,8 +204,7 @@ final appRouterProvider = Provider<GoRouter>((ref) {
 });
 
 bool _isProtected(String loc) {
-  if (loc == '/profile/welcome' ||
-      loc.startsWith('/profile/welcome')) {
+  if (loc == '/profile/welcome' || loc.startsWith('/profile/welcome')) {
     return false;
   }
   return loc == '/profile' || loc.startsWith('/profile/');
@@ -222,10 +219,7 @@ String? _sanitizeReturn(String? from) {
 }
 
 class _CourseAutoRedirect extends ConsumerWidget {
-  const _CourseAutoRedirect({
-    required this.courseId,
-    required this.isExact,
-  });
+  const _CourseAutoRedirect({required this.courseId, required this.isExact});
 
   final String courseId;
   final bool isExact;
@@ -236,17 +230,13 @@ class _CourseAutoRedirect extends ConsumerWidget {
 
     final modulesAsync = ref.watch(courseModulesProvider(courseId));
     return modulesAsync.when(
-      loading: () => const Scaffold(
-        body: Center(child: CircularProgressIndicator()),
-      ),
-      error: (e, _) => Scaffold(
-        body: Center(child: Text('Failed to load modules: $e')),
-      ),
+      loading: () =>
+          const Scaffold(body: Center(child: CircularProgressIndicator())),
+      error: (e, _) =>
+          Scaffold(body: Center(child: Text('Failed to load modules: $e'))),
       data: (modules) {
         if (modules.isEmpty) {
-          return const Scaffold(
-            body: Center(child: Text('No modules yet')),
-          );
+          return const Scaffold(body: Center(child: Text('No modules yet')));
         }
         WidgetsBinding.instance.addPostFrameCallback((_) {
           if (!context.mounted) return;

--- a/apps/mobile_app/lib/features/catalog/presentation/pages/lesson_page.dart
+++ b/apps/mobile_app/lib/features/catalog/presentation/pages/lesson_page.dart
@@ -11,11 +11,7 @@ import 'package:mobile_app/features/catalog/presentation/widgets/lesson/slide_ca
 import 'package:mobile_app/features/catalog/presentation/widgets/lesson/top_progress_bar.dart';
 
 class LessonPage extends ConsumerWidget {
-  const LessonPage({
-    required this.courseId,
-    required this.lessonId,
-    super.key,
-  });
+  const LessonPage({required this.courseId, required this.lessonId, super.key});
 
   final String courseId;
   final String lessonId;
@@ -90,15 +86,13 @@ class LessonPage extends ConsumerWidget {
         const SingleActivator(LogicalKeyboardKey.arrowLeft): () {
           final curr = ref.read(currentOrderProvider(lessonId));
           if (curr > minOrder) {
-            ref.read(currentOrderProvider(lessonId).notifier).state =
-                curr - 1;
+            ref.read(currentOrderProvider(lessonId).notifier).state = curr - 1;
           }
         },
         const SingleActivator(LogicalKeyboardKey.arrowRight): () {
           final curr = ref.read(currentOrderProvider(lessonId));
           if (curr < maxOrder) {
-            ref.read(currentOrderProvider(lessonId).notifier).state =
-                curr + 1;
+            ref.read(currentOrderProvider(lessonId).notifier).state = curr + 1;
           }
         },
       },
@@ -109,26 +103,40 @@ class LessonPage extends ConsumerWidget {
             TopProgressBar(current: clamped, min: minOrder, max: maxOrder),
             if (maxOrder > minOrder)
               Padding(
-                padding:
-                    const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 16,
+                  vertical: 4,
+                ),
                 child: Row(
                   mainAxisAlignment: MainAxisAlignment.spaceBetween,
                   children: [
                     IconButton(
                       icon: const Icon(Icons.chevron_left),
                       onPressed: clamped > minOrder
-                          ? () => ref
-                              .read(currentOrderProvider(lessonId).notifier)
-                              .state = clamped - 1
+                          ? () =>
+                                ref
+                                        .read(
+                                          currentOrderProvider(
+                                            lessonId,
+                                          ).notifier,
+                                        )
+                                        .state =
+                                    clamped - 1
                           : null,
                       tooltip: 'Previous',
                     ),
                     IconButton(
                       icon: const Icon(Icons.chevron_right),
                       onPressed: clamped < maxOrder
-                          ? () => ref
-                              .read(currentOrderProvider(lessonId).notifier)
-                              .state = clamped + 1
+                          ? () =>
+                                ref
+                                        .read(
+                                          currentOrderProvider(
+                                            lessonId,
+                                          ).notifier,
+                                        )
+                                        .state =
+                                    clamped + 1
                           : null,
                       tooltip: 'Next',
                     ),
@@ -142,8 +150,7 @@ class LessonPage extends ConsumerWidget {
                   padding: const EdgeInsets.all(16),
                   itemCount: currentSlides.length,
                   separatorBuilder: (_, __) => const SizedBox(height: 12),
-                  itemBuilder: (_, i) =>
-                      SlideCard(slide: currentSlides[i]),
+                  itemBuilder: (_, i) => SlideCard(slide: currentSlides[i]),
                 ),
               ),
             ),

--- a/apps/mobile_app/lib/features/catalog/presentation/pages/track_detail_page.dart
+++ b/apps/mobile_app/lib/features/catalog/presentation/pages/track_detail_page.dart
@@ -41,8 +41,7 @@ class TrackDetailPage extends ConsumerWidget {
         error: (e, _) => Center(child: Text('Error: $e')),
         data: (nodes) {
           final total = nodes.length;
-          final done =
-              nodes.where((n) => n.status == NodeStatus.done).length;
+          final done = nodes.where((n) => n.status == NodeStatus.done).length;
           final progress = total == 0 ? 0.0 : done / total;
 
           CourseNode? nextNode;
@@ -60,15 +59,14 @@ class TrackDetailPage extends ConsumerWidget {
             title: title,
             progress: progress,
             onBack: context.pop,
-            onContinue: (nextNode == null ||
-                    nextNode.status == NodeStatus.locked)
+            onContinue:
+                (nextNode == null || nextNode.status == NodeStatus.locked)
                 ? null
                 : () => openLesson(nextNode!),
             onTitleTap: () async {
               final modules = await modulesAsync.maybeWhen(
                 data: Future.value,
-                orElse: () =>
-                    ref.read(courseModulesProvider(courseId).future),
+                orElse: () => ref.read(courseModulesProvider(courseId).future),
               );
 
               if (!context.mounted) return;
@@ -77,17 +75,12 @@ class TrackDetailPage extends ConsumerWidget {
                 context: context,
                 useSafeArea: true,
                 isScrollControlled: true,
-                backgroundColor:
-                    Theme.of(context).colorScheme.surface,
+                backgroundColor: Theme.of(context).colorScheme.surface,
                 shape: const RoundedRectangleBorder(
-                  borderRadius: BorderRadius.vertical(
-                    top: Radius.circular(24),
-                  ),
+                  borderRadius: BorderRadius.vertical(top: Radius.circular(24)),
                 ),
-                builder: (ctx) => CourseModuleListSheet(
-                  title: title,
-                  modules: modules,
-                ),
+                builder: (ctx) =>
+                    CourseModuleListSheet(title: title, modules: modules),
               );
 
               if (!context.mounted) return;
@@ -104,14 +97,12 @@ class TrackDetailPage extends ConsumerWidget {
               final isTablet = w >= 700 && w < 1100;
               final cs = Theme.of(context).colorScheme;
 
-              final outline =
-                  LessonOutline(nodes: nodes, onTap: openLesson);
+              final outline = LessonOutline(nodes: nodes, onTap: openLesson);
 
               final metaPanel = CourseMetaPanel(
                 total: total,
                 done: done,
-                estimatedHours:
-                    (total * 0.15).toStringAsFixed(1),
+                estimatedHours: (total * 0.15).toStringAsFixed(1),
                 tags: const ['Beginner', 'Hands-on', 'Path'],
               );
 
@@ -163,16 +154,12 @@ class TrackDetailPage extends ConsumerWidget {
                       headerPill,
                       Expanded(
                         child: Row(
-                          crossAxisAlignment:
-                              CrossAxisAlignment.stretch,
+                          crossAxisAlignment: CrossAxisAlignment.stretch,
                           children: [
                             ConstrainedBox(
-                              constraints: const BoxConstraints(
-                                maxWidth: 360,
-                              ),
+                              constraints: const BoxConstraints(maxWidth: 360),
                               child: Material(
-                                color:
-                                    cs.surfaceContainerHighest,
+                                color: cs.surfaceContainerHighest,
                                 child: Padding(
                                   padding: const EdgeInsets.all(12),
                                   child: outline,
@@ -202,16 +189,12 @@ class TrackDetailPage extends ConsumerWidget {
                     headerPill,
                     Expanded(
                       child: Row(
-                        crossAxisAlignment:
-                            CrossAxisAlignment.stretch,
+                        crossAxisAlignment: CrossAxisAlignment.stretch,
                         children: [
                           ConstrainedBox(
-                            constraints: const BoxConstraints(
-                              maxWidth: 360,
-                            ),
+                            constraints: const BoxConstraints(maxWidth: 360),
                             child: Material(
-                              color:
-                                  cs.surfaceContainerHighest,
+                              color: cs.surfaceContainerHighest,
                               child: Padding(
                                 padding: const EdgeInsets.all(12),
                                 child: outline,
@@ -229,12 +212,9 @@ class TrackDetailPage extends ConsumerWidget {
                           ),
                           const VerticalDivider(width: 1),
                           ConstrainedBox(
-                            constraints: const BoxConstraints(
-                              maxWidth: 320,
-                            ),
+                            constraints: const BoxConstraints(maxWidth: 320),
                             child: Material(
-                              color:
-                                  cs.surfaceContainerHighest,
+                              color: cs.surfaceContainerHighest,
                               child: Padding(
                                 padding: const EdgeInsets.all(16),
                                 child: metaPanel,

--- a/apps/mobile_app/lib/features/catalog/presentation/viewmodels/lesson_providers.dart
+++ b/apps/mobile_app/lib/features/catalog/presentation/viewmodels/lesson_providers.dart
@@ -21,50 +21,50 @@ final quizWrongIndexProvider = StateProvider.family.autoDispose<int?, String>(
 
 final lessonHeaderProvider = FutureProvider.family
     .autoDispose<LessonHeader, String>((ref, lessonId) async {
-  final client = ref.read(supabaseProvider);
-  final idKey = int.tryParse(lessonId) ?? lessonId;
+      final client = ref.read(supabaseProvider);
+      final idKey = int.tryParse(lessonId) ?? lessonId;
 
-  final row = await client
-      .from('lessons')
-      .select('id,title,"order"')
-      .eq('id', idKey)
-      .single();
+      final row = await client
+          .from('lessons')
+          .select('id,title,"order"')
+          .eq('id', idKey)
+          .single();
 
-  final m = Map<String, dynamic>.from(row as Map);
-  return LessonHeader(
-    id: (m['id'] is num) ? (m['id'] as num).toString() : m['id'].toString(),
-    title: (m['title'] as String?) ?? 'Lesson',
-    order: (m['order'] as num?)?.toInt() ?? 1,
-  );
-});
+      final m = Map<String, dynamic>.from(row as Map);
+      return LessonHeader(
+        id: (m['id'] is num) ? (m['id'] as num).toString() : m['id'].toString(),
+        title: (m['title'] as String?) ?? 'Lesson',
+        order: (m['order'] as num?)?.toInt() ?? 1,
+      );
+    });
 
 final lessonSlidesProvider = FutureProvider.family
     .autoDispose<List<LessonSlide>, String>((ref, lessonId) async {
-  final client = ref.read(supabaseProvider);
-  final idKey = int.tryParse(lessonId) ?? lessonId;
+      final client = ref.read(supabaseProvider);
+      final idKey = int.tryParse(lessonId) ?? lessonId;
 
-  final rows = await client
-      .from('lesson_slides')
-      .select('id,lesson_id,"order",content_type,content')
-      .eq('lesson_id', idKey)
-      .order('order', ascending: true);
+      final rows = await client
+          .from('lesson_slides')
+          .select('id,lesson_id,"order",content_type,content')
+          .eq('lesson_id', idKey)
+          .order('order', ascending: true);
 
-  final list = (rows as List)
-      .map((e) => Map<String, dynamic>.from(e as Map))
-      .map(
-        (m) => LessonSlide(
-          id: (m['id'] is num)
-              ? (m['id'] as num).toString()
-              : m['id'].toString(),
-          contentType: m['content_type'] as String,
-          content: Map<String, dynamic>.from(m['content'] as Map),
-          order: (m['order'] as num?)?.toInt() ?? 1,
-        ),
-      )
-      .toList();
+      final list = (rows as List)
+          .map((e) => Map<String, dynamic>.from(e as Map))
+          .map(
+            (m) => LessonSlide(
+              id: (m['id'] is num)
+                  ? (m['id'] as num).toString()
+                  : m['id'].toString(),
+              contentType: m['content_type'] as String,
+              content: Map<String, dynamic>.from(m['content'] as Map),
+              order: (m['order'] as num?)?.toInt() ?? 1,
+            ),
+          )
+          .toList();
 
-  return list;
-});
+      return list;
+    });
 
 final currentOrderProvider = StateProvider.family.autoDispose<int, String>(
   (ref, _) => 1,
@@ -72,7 +72,7 @@ final currentOrderProvider = StateProvider.family.autoDispose<int, String>(
 
 final lessonCompletedProvider = FutureProvider.family
     .autoDispose<bool, LessonKey>((ref, key) async {
-  final store = ref.read(progressStoreProvider);
-  final map = await store.getLessonCompletion(key.courseId);
-  return map[key.lessonId] ?? false;
-});
+      final store = ref.read(progressStoreProvider);
+      final map = await store.getLessonCompletion(key.courseId);
+      return map[key.lessonId] ?? false;
+    });

--- a/apps/mobile_app/lib/features/catalog/presentation/viewmodels/module_providers.dart
+++ b/apps/mobile_app/lib/features/catalog/presentation/viewmodels/module_providers.dart
@@ -5,161 +5,157 @@ import 'package:mobile_app/features/catalog/presentation/viewmodels/lesson_provi
 
 typedef ModuleKey = ({String courseId, String moduleId});
 
-final courseModulesProvider =
-    FutureProvider.family.autoDispose<List<CourseModule>, String>(
-  (ref, courseId) async {
-    final client = ref.read(supabaseProvider);
-    final courseKey = int.tryParse(courseId) ?? courseId;
+final courseModulesProvider = FutureProvider.family
+    .autoDispose<List<CourseModule>, String>((ref, courseId) async {
+      final client = ref.read(supabaseProvider);
+      final courseKey = int.tryParse(courseId) ?? courseId;
 
-    final modRows = await client
-        .from('modules')
-        .select('id,title,"order"')
-        .eq('course_id', courseKey)
-        .order('order', ascending: true);
+      final modRows = await client
+          .from('modules')
+          .select('id,title,"order"')
+          .eq('course_id', courseKey)
+          .order('order', ascending: true);
 
-    final modules = (modRows as List)
-        .map((e) => Map<String, dynamic>.from(e as Map))
-        .toList();
+      final modules = (modRows as List)
+          .map((e) => Map<String, dynamic>.from(e as Map))
+          .toList();
 
-    if (modules.isEmpty) return const <CourseModule>[];
+      if (modules.isEmpty) return const <CourseModule>[];
 
-    final moduleIds = modules
-        .map<int>((m) => (m['id'] as num).toInt())
-        .toList(growable: false);
+      final moduleIds = modules
+          .map<int>((m) => (m['id'] as num).toInt())
+          .toList(growable: false);
 
-    final lessonRows = await client
-        .from('lessons')
-        .select('id,module_id')
-        .inFilter('module_id', moduleIds);
+      final lessonRows = await client
+          .from('lessons')
+          .select('id,module_id')
+          .inFilter('module_id', moduleIds);
 
-    final lessons = (lessonRows as List)
-        .map((e) => Map<String, dynamic>.from(e as Map))
-        .toList();
+      final lessons = (lessonRows as List)
+          .map((e) => Map<String, dynamic>.from(e as Map))
+          .toList();
 
-    final lessonsByModule = <int, List<int>>{};
-    for (final row in lessons) {
-      final mid = (row['module_id'] as num).toInt();
-      final lid = (row['id'] as num).toInt();
-      (lessonsByModule[mid] ??= <int>[]).add(lid);
-    }
+      final lessonsByModule = <int, List<int>>{};
+      for (final row in lessons) {
+        final mid = (row['module_id'] as num).toInt();
+        final lid = (row['id'] as num).toInt();
+        (lessonsByModule[mid] ??= <int>[]).add(lid);
+      }
 
-    final uid = client.auth.currentUser?.id;
-    final completedLessonIds = <int>{};
-    if (uid != null && lessons.isNotEmpty) {
-      final allLessonIds = lessons
+      final uid = client.auth.currentUser?.id;
+      final completedLessonIds = <int>{};
+      if (uid != null && lessons.isNotEmpty) {
+        final allLessonIds = lessons
+            .map<int>((l) => (l['id'] as num).toInt())
+            .toList(growable: false);
+
+        final upRows = await client
+            .from('user_progress')
+            .select('lesson_id,is_completed')
+            .eq('user_id', uid)
+            .inFilter('lesson_id', allLessonIds);
+
+        for (final e in (upRows as List)) {
+          final m = Map<String, dynamic>.from(e as Map);
+          if (m['is_completed'] == true) {
+            completedLessonIds.add((m['lesson_id'] as num).toInt());
+          }
+        }
+      }
+
+      final result = <CourseModule>[];
+      for (final m in modules) {
+        final mid = (m['id'] as num).toInt();
+        final title = (m['title'] as String?) ?? 'Module';
+        final order = (m['order'] as num?)?.toInt() ?? 1;
+
+        final lessonIds = lessonsByModule[mid] ?? const <int>[];
+        final total = lessonIds.length;
+        var done = 0;
+        for (final id in lessonIds) {
+          if (completedLessonIds.contains(id)) done++;
+        }
+
+        result.add(
+          CourseModule(
+            id: '$mid',
+            title: title,
+            order: order,
+            totalLessons: total,
+            doneLessons: done,
+          ),
+        );
+      }
+
+      result.sort((a, b) => a.order.compareTo(b.order));
+      return result;
+    });
+
+final modulePathProvider = FutureProvider.family
+    .autoDispose<List<CourseNode>, ModuleKey>((ref, key) async {
+      final client = ref.read(supabaseProvider);
+      final modKey = int.tryParse(key.moduleId) ?? key.moduleId;
+
+      final rows = await client
+          .from('lessons')
+          .select('id,title,"order"')
+          .eq('module_id', modKey)
+          .order('order', ascending: true);
+
+      final lessons = (rows as List)
+          .map((e) => Map<String, dynamic>.from(e as Map))
+          .toList();
+
+      final ids = lessons
           .map<int>((l) => (l['id'] as num).toInt())
           .toList(growable: false);
 
-      final upRows = await client
-          .from('user_progress')
-          .select('lesson_id,is_completed')
-          .eq('user_id', uid)
-          .inFilter('lesson_id', allLessonIds);
+      final uid = client.auth.currentUser?.id;
+      final completed = <int>{};
+      if (uid != null && ids.isNotEmpty) {
+        final upRows = await client
+            .from('user_progress')
+            .select('lesson_id,is_completed')
+            .eq('user_id', uid)
+            .inFilter('lesson_id', ids);
 
-      for (final e in (upRows as List)) {
-        final m = Map<String, dynamic>.from(e as Map);
-        if (m['is_completed'] == true) {
-          completedLessonIds.add((m['lesson_id'] as num).toInt());
+        for (final e in (upRows as List)) {
+          final m = Map<String, dynamic>.from(e as Map);
+          if (m['is_completed'] == true) {
+            completed.add((m['lesson_id'] as num).toInt());
+          }
         }
       }
-    }
 
-    final result = <CourseModule>[];
-    for (final m in modules) {
-      final mid = (m['id'] as num).toInt();
-      final title = (m['title'] as String?) ?? 'Module';
-      final order = (m['order'] as num?)?.toInt() ?? 1;
+      final result = <CourseNode>[];
+      var unlockedGiven = false;
 
-      final lessonIds = lessonsByModule[mid] ?? const <int>[];
-      final total = lessonIds.length;
-      var done = 0;
-      for (final id in lessonIds) {
-        if (completedLessonIds.contains(id)) done++;
-      }
+      for (final m in lessons) {
+        final idNum = (m['id'] as num).toInt();
+        final title = (m['title'] as String?) ?? 'Lesson';
+        final order = (m['order'] as num?)?.toInt() ?? 0;
 
-      result.add(
-        CourseModule(
-          id: '$mid',
-          title: title,
-          order: order,
-          totalLessons: total,
-          doneLessons: done,
-        ),
-      );
-    }
-
-    result.sort((a, b) => a.order.compareTo(b.order));
-    return result;
-  },
-);
-
-final modulePathProvider =
-    FutureProvider.family.autoDispose<List<CourseNode>, ModuleKey>(
-  (ref, key) async {
-    final client = ref.read(supabaseProvider);
-    final modKey = int.tryParse(key.moduleId) ?? key.moduleId;
-
-    final rows = await client
-        .from('lessons')
-        .select('id,title,"order"')
-        .eq('module_id', modKey)
-        .order('order', ascending: true);
-
-    final lessons = (rows as List)
-        .map((e) => Map<String, dynamic>.from(e as Map))
-        .toList();
-
-    final ids = lessons
-        .map<int>((l) => (l['id'] as num).toInt())
-        .toList(growable: false);
-
-    final uid = client.auth.currentUser?.id;
-    final completed = <int>{};
-    if (uid != null && ids.isNotEmpty) {
-      final upRows = await client
-          .from('user_progress')
-          .select('lesson_id,is_completed')
-          .eq('user_id', uid)
-          .inFilter('lesson_id', ids);
-
-      for (final e in (upRows as List)) {
-        final m = Map<String, dynamic>.from(e as Map);
-        if (m['is_completed'] == true) {
-          completed.add((m['lesson_id'] as num).toInt());
+        NodeStatus status;
+        if (completed.contains(idNum)) {
+          status = NodeStatus.done;
+        } else if (!unlockedGiven) {
+          status = NodeStatus.available;
+          unlockedGiven = true;
+        } else {
+          status = NodeStatus.locked;
         }
-      }
-    }
 
-    final result = <CourseNode>[];
-    var unlockedGiven = false;
-
-    for (final m in lessons) {
-      final idNum = (m['id'] as num).toInt();
-      final title = (m['title'] as String?) ?? 'Lesson';
-      final order = (m['order'] as num?)?.toInt() ?? 0;
-
-      NodeStatus status;
-      if (completed.contains(idNum)) {
-        status = NodeStatus.done;
-      } else if (!unlockedGiven) {
-        status = NodeStatus.available;
-        unlockedGiven = true;
-      } else {
-        status = NodeStatus.locked;
+        result.add(
+          CourseNode(
+            id: '$idNum',
+            title: title,
+            type: NodeType.lesson,
+            status: status,
+            order: order,
+            moduleId: key.moduleId,
+          ),
+        );
       }
 
-      result.add(
-        CourseNode(
-          id: '$idNum',
-          title: title,
-          type: NodeType.lesson,
-          status: status,
-          order: order,
-          moduleId: key.moduleId,
-        ),
-      );
-    }
-
-    return result;
-  },
-);
+      return result;
+    });

--- a/apps/mobile_app/lib/features/catalog/presentation/widgets/course_header.dart
+++ b/apps/mobile_app/lib/features/catalog/presentation/widgets/course_header.dart
@@ -2,7 +2,8 @@ import 'package:flutter/material.dart';
 
 class CourseHeader extends StatelessWidget {
   const CourseHeader({
-    required this.title, super.key,
+    required this.title,
+    super.key,
     this.progress = 0,
     this.onContinue,
     this.onBack,
@@ -77,15 +78,17 @@ class CourseHeader extends StatelessWidget {
                   onTap: onTitleTap,
                   behavior: HitTestBehavior.opaque,
                   child: Padding(
-                    padding: const EdgeInsets.symmetric(horizontal: 8, 
-                      vertical: 6),
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 8,
+                      vertical: 6,
+                    ),
                     child: Text(
                       title,
                       maxLines: 1,
                       overflow: TextOverflow.ellipsis,
                       style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                            fontWeight: FontWeight.w700,
-                          ),
+                        fontWeight: FontWeight.w700,
+                      ),
                     ),
                   ),
                 ),

--- a/apps/mobile_app/lib/features/catalog/presentation/widgets/course_module_list_sheet.dart
+++ b/apps/mobile_app/lib/features/catalog/presentation/widgets/course_module_list_sheet.dart
@@ -3,7 +3,9 @@ import 'package:mobile_app/core/models/module.dart';
 
 class CourseModuleListSheet extends StatelessWidget {
   const CourseModuleListSheet({
-    required this.title, required this.modules, super.key,
+    required this.title,
+    required this.modules,
+    super.key,
   });
 
   final String title;
@@ -31,10 +33,9 @@ class CourseModuleListSheet extends StatelessWidget {
             Text(
               title,
               textAlign: TextAlign.center,
-              style: Theme.of(context)
-                  .textTheme
-                  .titleMedium
-                  ?.copyWith(fontWeight: FontWeight.w700),
+              style: Theme.of(
+                context,
+              ).textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w700),
             ),
             const SizedBox(height: 12),
             Flexible(

--- a/apps/mobile_app/lib/features/catalog/presentation/widgets/lesson/finish_bar.dart
+++ b/apps/mobile_app/lib/features/catalog/presentation/widgets/lesson/finish_bar.dart
@@ -1,10 +1,7 @@
 import 'package:flutter/material.dart';
 
 class FinishBar extends StatelessWidget {
-  const FinishBar({
-    required this.isCompleted, super.key,
-    this.onFinish,
-  });
+  const FinishBar({required this.isCompleted, super.key, this.onFinish});
 
   final bool isCompleted;
   final VoidCallback? onFinish;

--- a/apps/mobile_app/lib/features/catalog/presentation/widgets/lesson/quiz_card.dart
+++ b/apps/mobile_app/lib/features/catalog/presentation/widgets/lesson/quiz_card.dart
@@ -43,10 +43,14 @@ class QuizCard extends ConsumerWidget {
                 onSelect: revealed
                     ? null
                     : () {
-                        ref.read(quizSelectedProvider(slide.id)
-                          .notifier).state = i;
-                        ref.read(quizWrongIndexProvider(slide.id)
-                          .notifier).state = null;
+                        ref
+                                .read(quizSelectedProvider(slide.id).notifier)
+                                .state =
+                            i;
+                        ref
+                                .read(quizWrongIndexProvider(slide.id).notifier)
+                                .state =
+                            null;
                       },
               ),
 
@@ -59,13 +63,25 @@ class QuizCard extends ConsumerWidget {
                       ? null
                       : () {
                           if (selected == correctIndex) {
-                            ref.read(quizRevealedProvider(slide.id)
-                              .notifier).state = true;
-                            ref.read(quizWrongIndexProvider(slide.id)
-                              .notifier).state = null;
+                            ref
+                                    .read(
+                                      quizRevealedProvider(slide.id).notifier,
+                                    )
+                                    .state =
+                                true;
+                            ref
+                                    .read(
+                                      quizWrongIndexProvider(slide.id).notifier,
+                                    )
+                                    .state =
+                                null;
                           } else {
-                            ref.read(quizWrongIndexProvider(slide.id)
-                              .notifier).state = selected;
+                            ref
+                                    .read(
+                                      quizWrongIndexProvider(slide.id).notifier,
+                                    )
+                                    .state =
+                                selected;
                           }
                         },
                   child: const Text('Check answer'),
@@ -74,12 +90,14 @@ class QuizCard extends ConsumerWidget {
                 if (revealed)
                   TextButton(
                     onPressed: () {
-                      ref.read(quizSelectedProvider(slide.id)
-                        .notifier).state = null;
-                      ref.read(quizRevealedProvider(slide.id)
-                        .notifier).state = false;
-                      ref.read(quizWrongIndexProvider(slide.id)
-                        .notifier).state = null;
+                      ref.read(quizSelectedProvider(slide.id).notifier).state =
+                          null;
+                      ref.read(quizRevealedProvider(slide.id).notifier).state =
+                          false;
+                      ref
+                              .read(quizWrongIndexProvider(slide.id).notifier)
+                              .state =
+                          null;
                     },
                     child: const Text('Try again'),
                   ),
@@ -140,8 +158,8 @@ class _AnswerOptionTile extends StatelessWidget {
         ? Colors.green.withValues(alpha: 0.25)
         : Colors.green.withValues(alpha: 0.12);
 
-    final isMarkedWrong = wrongIndex != 
-      null && wrongIndex == index && !revealed;
+    final isMarkedWrong =
+        wrongIndex != null && wrongIndex == index && !revealed;
 
     late Color bg;
     late Color border;
@@ -228,8 +246,9 @@ class _AnswerIndexBadge extends StatelessWidget {
     final bg = isCorrect
         ? Colors.green
         : (revealed ? cs.surfaceContainerHighest : cs.surfaceContainerHighest);
-    final fg =
-        isCorrect ? Colors.white : Theme.of(context).textTheme.bodySmall?.color;
+    final fg = isCorrect
+        ? Colors.white
+        : Theme.of(context).textTheme.bodySmall?.color;
 
     return Container(
       padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
@@ -291,8 +310,8 @@ class _ResultBanner extends StatelessWidget {
 
     final bg = correct
         ? (Theme.of(context).brightness == Brightness.dark
-            ? Colors.green.withValues(alpha: 0.25)
-            : Colors.green.withValues(alpha: 0.12))
+              ? Colors.green.withValues(alpha: 0.25)
+              : Colors.green.withValues(alpha: 0.12))
         : cs.errorContainer;
 
     final icon = correct ? Icons.check_circle : Icons.close_rounded;

--- a/apps/mobile_app/lib/features/catalog/presentation/widgets/lesson/slide_card.dart
+++ b/apps/mobile_app/lib/features/catalog/presentation/widgets/lesson/slide_card.dart
@@ -8,8 +8,10 @@ import 'package:flutter_svg/flutter_svg.dart';
 import 'package:mobile_app/core/models/lesson.dart';
 import 'package:mobile_app/features/catalog/presentation/widgets/lesson/quiz_card.dart';
 
-String normalizeMd(String s) =>
-    s.replaceAll('\r\n', '\n').replaceAll(r'\r\n', '\n').replaceAll(r'\n', '\n');
+String normalizeMd(String s) => s
+    .replaceAll('\r\n', '\n')
+    .replaceAll(r'\r\n', '\n')
+    .replaceAll(r'\n', '\n');
 
 class SlideCard extends StatelessWidget {
   const SlideCard({required this.slide, super.key});
@@ -52,7 +54,8 @@ class _TextCard extends StatelessWidget {
     };
     final isCenter = alignStr == 'center';
 
-    final blocks = (content['blocks'] as List?)
+    final blocks =
+        (content['blocks'] as List?)
             ?.map((e) => Map<String, dynamic>.from(e as Map))
             .toList() ??
         const <Map<String, dynamic>>[];
@@ -71,10 +74,9 @@ class _TextCard extends StatelessWidget {
                 padding: const EdgeInsets.only(bottom: 12),
                 child: Text(
                   title,
-                  style: Theme.of(context)
-                      .textTheme
-                      .headlineSmall
-                      ?.copyWith(fontWeight: FontWeight.w700),
+                  style: Theme.of(context).textTheme.headlineSmall?.copyWith(
+                    fontWeight: FontWeight.w700,
+                  ),
                   textAlign: isCenter ? TextAlign.center : TextAlign.start,
                 ),
               ),
@@ -130,9 +132,9 @@ class _ImageCard extends StatelessWidget {
 
     Widget imageWidget;
     if (bytes != null) {
-      imageWidget =
-          isSvg ? SvgPicture.memory(bytes, fit: fit) : Image.memory(bytes, 
-            fit: fit);
+      imageWidget = isSvg
+          ? SvgPicture.memory(bytes, fit: fit)
+          : Image.memory(bytes, fit: fit);
     } else {
       if (url.isEmpty) return const SizedBox.shrink();
       imageWidget = isSvg
@@ -270,12 +272,12 @@ class _HeroBlock extends StatelessWidget {
     final w = (asset != null && asset!.toLowerCase().endsWith('.svg'))
         ? SvgPicture.asset(asset!, height: height)
         : (asset != null)
-            ? Image.asset(asset!, height: height)
-            : (url != null && url!.toLowerCase().endsWith('.svg'))
-                ? SvgPicture.network(url!, height: height)
-                : (url != null)
-                    ? Image.network(url!, height: height)
-                    : const SizedBox.shrink();
+        ? Image.asset(asset!, height: height)
+        : (url != null && url!.toLowerCase().endsWith('.svg'))
+        ? SvgPicture.network(url!, height: height)
+        : (url != null)
+        ? Image.network(url!, height: height)
+        : const SizedBox.shrink();
 
     final alignment = switch (align) {
       'start' => Alignment.centerLeft,

--- a/apps/mobile_app/lib/features/catalog/presentation/widgets/lesson/top_progress_bar.dart
+++ b/apps/mobile_app/lib/features/catalog/presentation/widgets/lesson/top_progress_bar.dart
@@ -2,7 +2,10 @@ import 'package:flutter/material.dart';
 
 class TopProgressBar extends StatelessWidget {
   const TopProgressBar({
-    required this.current, required this.min, required this.max, super.key,
+    required this.current,
+    required this.min,
+    required this.max,
+    super.key,
   });
 
   final int current;

--- a/apps/mobile_app/lib/features/leaderboard/leaderboard_page.dart
+++ b/apps/mobile_app/lib/features/leaderboard/leaderboard_page.dart
@@ -94,10 +94,7 @@ class _LeaderboardPageState extends State<LeaderboardPage> {
       appBar: AppBar(
         title: const Text('Leaderboards'),
         actions: [
-          IconButton(
-            onPressed: _refresh,
-            icon: const Icon(Icons.refresh),
-          ),
+          IconButton(onPressed: _refresh, icon: const Icon(Icons.refresh)),
         ],
       ),
       body: RefreshIndicator(
@@ -193,14 +190,15 @@ class _LeaderboardPageState extends State<LeaderboardPage> {
                     return ListTile(
                       isThreeLine: true,
                       leading: CircleAvatar(
-                        foregroundImage: (r.avatarUrl != null 
-                          && r.avatarUrl!.isNotEmpty)
+                        foregroundImage:
+                            (r.avatarUrl != null && r.avatarUrl!.isNotEmpty)
                             ? NetworkImage(r.avatarUrl!)
                             : null,
                         onForegroundImageError: (_, __) {},
                         child: Text(
-                          r.displayName.isNotEmpty 
-                            ? r.displayName[0].toUpperCase() : '?',
+                          r.displayName.isNotEmpty
+                              ? r.displayName[0].toUpperCase()
+                              : '?',
                         ),
                       ),
                       title: Text(
@@ -218,11 +216,19 @@ class _LeaderboardPageState extends State<LeaderboardPage> {
                           mainAxisSize: MainAxisSize.min,
                           crossAxisAlignment: CrossAxisAlignment.end,
                           children: [
-                            Text('Season ${r.seasonExp}', style: 
-                              const TextStyle(fontWeight: FontWeight.w600)),
-                            Text('Total ${r.totalExp}', 
-                              style: const TextStyle(fontSize: 12, 
-                                color: Colors.grey)),
+                            Text(
+                              'Season ${r.seasonExp}',
+                              style: const TextStyle(
+                                fontWeight: FontWeight.w600,
+                              ),
+                            ),
+                            Text(
+                              'Total ${r.totalExp}',
+                              style: const TextStyle(
+                                fontSize: 12,
+                                color: Colors.grey,
+                              ),
+                            ),
                           ],
                         ),
                       ),
@@ -247,9 +253,7 @@ class _StatLine extends StatelessWidget {
   Widget build(BuildContext context) {
     return Row(
       children: [
-        Expanded(
-          child: Text(label, style: const TextStyle(fontSize: 16)),
-        ),
+        Expanded(child: Text(label, style: const TextStyle(fontSize: 16))),
         Text(
           '$value',
           style: const TextStyle(fontSize: 18, fontWeight: FontWeight.w600),
@@ -265,10 +269,7 @@ class _UserXP {
     required this.seasonExp,
     required this.level,
   });
-  const _UserXP.empty()
-      : totalExp = 0,
-        seasonExp = 0,
-        level = 1;
+  const _UserXP.empty() : totalExp = 0, seasonExp = 0, level = 1;
   final int totalExp;
   final int seasonExp;
   final int level;

--- a/apps/mobile_app/test/lesson_page_quiz_test.dart
+++ b/apps/mobile_app/test/lesson_page_quiz_test.dart
@@ -32,22 +32,26 @@ void main() {
   const courseId = '1';
   const slideId = 'q1';
 
-  final headerOverride = lessonHeaderProvider(lessonId)
-    .overrideWith((ref) async {
+  final headerOverride = lessonHeaderProvider(lessonId).overrideWith((
+    ref,
+  ) async {
     return LessonHeader(id: lessonId, title: 'Lesson (Test)', order: 1);
   });
 
-  final slidesOverride = lessonSlidesProvider(lessonId)
-    .overrideWith((ref) async {
+  final slidesOverride = lessonSlidesProvider(lessonId).overrideWith((
+    ref,
+  ) async {
     return <LessonSlide>[_quizSlide(id: slideId, correctIndex: 1)];
   });
 
-  final completedOverride = lessonCompletedProvider(
-    (courseId: courseId, lessonId: lessonId),
-  ).overrideWith((ref) async => false);
+  final completedOverride = lessonCompletedProvider((
+    courseId: courseId,
+    lessonId: lessonId,
+  )).overrideWith((ref) async => false);
 
-  testWidgets('quiz flow: wrong -> banner; correct -> success & lock', 
-    (tester) async {
+  testWidgets('quiz flow: wrong -> banner; correct -> success & lock', (
+    tester,
+  ) async {
     await tester.pumpWidget(
       ProviderScope(
         overrides: [headerOverride, slidesOverride, completedOverride],

--- a/apps/mobile_app/test/quiz_logic_test.dart
+++ b/apps/mobile_app/test/quiz_logic_test.dart
@@ -20,8 +20,8 @@ void main() {
     container.read(quizSelectedProvider(slideId).notifier).state = 0;
     expect(container.read(quizSelectedProvider(slideId)), 0);
 
-    container.read(quizWrongIndexProvider(slideId).notifier).state =
-        container.read(quizSelectedProvider(slideId));
+    container.read(quizWrongIndexProvider(slideId).notifier).state = container
+        .read(quizSelectedProvider(slideId));
     expect(container.read(quizWrongIndexProvider(slideId)), 0);
     expect(container.read(quizRevealedProvider(slideId)), false);
 


### PR DESCRIPTION
## Summary / Goal

Deliver a **minimum viable leaderboard**: show the current user’s **level** and **XP**, establish a **season-based** progression model, and add a **deduplicated XP-award pipeline** that safely aggregates XP for both season and lifetime totals. This PR lays the groundwork for a full ranking view.

---

## Levels & Seasons

* **XP sources** (initial):

  * `lesson_completed` → default **50 XP**
  * `module_completed` → default **150 XP**
  * Values come from `xp_rules` (fallbacks apply if a key is missing).
* **Seasons**: All XP is scoped to the active season via `current_season_id()`.

  * **Global XP** → `user_global_progress.total_exp` (lifetime).
  * **Season XP** → `user_season_progress.season_exp` (per active season).
* **Level (temporary client rule)**:
  `level = (total_exp ~/ 1000) + 1`
  (to be replaced later with a DB-driven curve/thresholds).

---

## Frontend (Flutter)

* `LeaderboardPage`:

  * Fetches `total_exp` from `user_global_progress` and `season_exp` from `user_season_progress` for the **current user**.
  * Computes a simple level from total XP.
  * Includes pull-to-refresh and minimal UI for verification.
* Assumes RLS permits the current user to **read their own** progress rows.

---

## Backend / DB

### New Tables

* **`exp_events`** — XP event journal
  **Columns**: `id` (bigint, PK), `user_id` (uuid, FK → `auth.users`), `season_id` (uuid, FK → `seasons.id`),
  `amount` (int), `reason` (text), `meta` (jsonb), `dedupe_key` (text), `created_at` (timestamptz default now).
  **Constraints/Indexes**:

  * `UNIQUE (user_id, season_id, dedupe_key)`
  * index on `(user_id, season_id)`
    **RLS**: `SELECT` by owner; writes go through server-side functions.

* **`user_season_progress`** — per-season XP aggregate
  **Columns**: `user_id` (uuid, FK), `season_id` (uuid, FK), `season_exp` (int default 0), `updated_at` (timestamptz default now).
  **Constraints/Indexes**:

  * `UNIQUE (user_id, season_id)`
  * index on `season_id`
    **RLS**: `SELECT` by owner; upserts via server-side function.

* **`user_global_progress`** — lifetime XP aggregate
  **Columns**: `user_id` (uuid, PK), `total_exp` (int default 0), `updated_at` (timestamptz default now).
  **Constraints**:

  * `UNIQUE (user_id)` (same as PK)
    **RLS**: `SELECT` by owner; upserts via server-side function.

### Existing Tables (touched)

* **`user_progress`**:

  * Ensured `UNIQUE (user_id, lesson_id)` for idempotent upserts.
  * Trigger wired to award XP on lesson completion.

### Functions & Triggers

* **`award_exp_dedup(user_id, season_id, amount, reason, meta, dedupe_key)`**

  * `INSERT INTO exp_events ... ON CONFLICT (user_id, season_id, dedupe_key) DO NOTHING` (idempotent event log).
  * If inserted (i.e., no conflict), **upsert** into:

    * `user_season_progress (user_id, season_id)` → `season_exp += amount`
    * `user_global_progress (user_id)` → `total_exp += amount`
* **`tg_award_on_user_progress()`**

  * Trigger on `user_progress` to grant XP when a lesson is marked completed.
  * Also checks if the whole module’s lessons are completed to award a module bonus.

### Constraints / Keys (added or verified)

* `exp_events (user_id, season_id, dedupe_key)` → **UNIQUE**
* `user_season_progress (user_id, season_id)` → **UNIQUE**
* `user_global_progress (user_id)` → **UNIQUE/PK**
* `user_progress (user_id, lesson_id)` → **UNIQUE**

### RLS (high level)

* Enable RLS on `exp_events`, `user_season_progress`, `user_global_progress`.
* Policies:

  * `SELECT`: `using (auth.uid() = user_id)`
  * Writes restricted to **SECURITY DEFINER** functions or a trusted service role.

### Migrations (outline)

* Create: `exp_events`, `user_season_progress`, `user_global_progress`
* Add unique keys and indexes listed above
* Hook functions & triggers
* Seed `xp_rules` defaults (if missing)

---

## Plan Next

* **Leaderboard View**: `leaderboard_v` combining profiles + ranks (e.g., `dense_rank()`), pagination-ready.
* **Level Formula**: move to DB (thresholds/curve in `xp_rules` or a dedicated table) and expose via view/function.
* **Season Lifecycle**: season closing/archiving, carry-over logic, scheduled jobs (`pg_cron`).
* **Abuse Guardrails**: idempotency across sources, basic anti-fraud checks.
* **RLS/Public Read**: expose only aggregated leaderboard view for public reading; keep raw tables private.
* **Performance**: targeted indexes; optional materialized view with refresh strategy.
* **UX**: avatars and display names from `profiles`, progress-to-next-level bar, season/global toggles.
* **Tests**: unit for `award_exp_dedup`, integration for trigger, e2e for page.

---

## How to Test

1. Complete a lesson (or flip `is_completed`): season and global XP should increase exactly once per `dedupe_key`.
2. Open `LeaderboardPage`: level, total XP, and season XP are displayed.
3. Try to award the **same** event again: no duplicate XP (conflict on `(user_id, season_id, dedupe_key)`).
4. Pull-to-refresh: values update accordingly.

---
