### PR TITLE
test: increase mobile coverage (sprint 09–11)

### DIFF
--- a/apps/mobile_app/test/settings_bottom_sheet_smoke_test.dart
+++ b/apps/mobile_app/test/settings_bottom_sheet_smoke_test.dart
@@ -1,0 +1,55 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:mobile_app/features/settings/presentation/widgets/settings_bottom_sheet.dart';
+
+Future<void> pumpUntilVisible(
+  WidgetTester tester,
+  Finder finder, {
+  Duration step = const Duration(milliseconds: 50),
+  int maxTicks = 40,
+}) async {
+  for (var i = 0; i < maxTicks; i++) {
+    await tester.pump(step);
+    if (finder.evaluate().isNotEmpty) return;
+  }
+  fail('Widget not visible: $finder');
+}
+
+void main() {
+  testWidgets('SettingsBottomSheet opens', (tester) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        child: MaterialApp(
+          home: Builder(
+            builder: (outerCtx) => Scaffold(
+              body: Center(
+                child: ElevatedButton(
+                  onPressed: () {
+                    showModalBottomSheet<void>(
+                      context: outerCtx,
+                      builder: (_) =>
+                          SettingsBottomSheet(sheetContext: outerCtx),
+                    );
+                  },
+                  child: const Text('Open'),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('Open'));
+
+    final sheetFinder = find.byType(SettingsBottomSheet);
+    await pumpUntilVisible(tester, sheetFinder);
+
+    expect(sheetFinder, findsOneWidget);
+
+    Navigator.of(tester.element(sheetFinder)).pop();
+    await tester.pump(const Duration(milliseconds: 200));
+  });
+}

--- a/apps/mobile_app/test/splash_page_smoke_test.dart
+++ b/apps/mobile_app/test/splash_page_smoke_test.dart
@@ -1,0 +1,14 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobile_app/features/launch/splash_page.dart';
+
+void main() {
+  testWidgets('SplashPage builds', (tester) async {
+    await tester.pumpWidget(
+      const ProviderScope(child: MaterialApp(home: SplashPage())),
+    );
+    expect(find.byType(SplashPage), findsOneWidget);
+    await tester.pump(const Duration(milliseconds: 16));
+  });
+}

--- a/apps/mobile_app/test/xp_chip_widget_test.dart
+++ b/apps/mobile_app/test/xp_chip_widget_test.dart
@@ -1,0 +1,42 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:mobile_app/features/leaderboard/presentation/widgets/xp_chip.dart';
+
+void main() {
+  testWidgets('XpChip shows label and value', (tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(
+          body: Center(child: XpChip(label: 'XP', value: 123)),
+        ),
+      ),
+    );
+
+    expect(find.byType(XpChip), findsOneWidget);
+    expect(find.text('XP: 123'), findsOneWidget);
+  });
+
+  testWidgets('XpChip updates when value changes', (tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(
+          body: Center(child: XpChip(label: 'XP', value: 10)),
+        ),
+      ),
+    );
+    expect(find.text('XP: 10'), findsOneWidget);
+
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(
+          body: Center(child: XpChip(label: 'XP', value: 999)),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    expect(find.text('XP: 999'), findsOneWidget);
+    expect(find.text('XP: 10'), findsNothing);
+  });
+}


### PR DESCRIPTION
## Description
Increase widget-test coverage with safe, network-free smoke tests.

## What’s included
- Add `splash_page_smoke_test.dart` — mounts `SplashPage`.
- Add `settings_bottom_sheet_smoke_test.dart` — opens bottom sheet via `showModalBottomSheet<void>`.
  - Deflake: avoid `pumpAndSettle`; small tick loop (`pumpUntilVisible`).
- Add `xp_chip_widget_test.dart` — verifies label/value rendering and updates.

## How to test
```bash
flutter test -r compact \
  test/splash_page_smoke_test.dart \
  test/settings_bottom_sheet_smoke_test.dart \
  test/xp_chip_widget_test.dart

 # Or by one command
flutter test
